### PR TITLE
refactor(ui): Notification no longer gets added if already on the pane

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -253,7 +253,7 @@ export const store = createStore({
         setTimeSinceAutoSave(state, payload) { state.timeSinceAutoSave = payload },
         setTimeSinceAutoEmc(state, payload) { state.timeSinceAutoEmc = payload },
         /*--------------------------------------------------------------------*/
-        addNotif(state, payload) { if (!(state.notifications.includes(payload))) state.notifications.push(payload) },
+        addNotif(state, payload) { if (!(state.notifications.includes(payload) || state.activePane === payload)) state.notifications.push(payload) },
         /*--------------------------------------------------------------------*/
         setDataProd(state, payload) { if (payload.prod  != state.data[payload.id].prod) state.data[payload.id].prod  = payload.prod },
         setDataBoost(state, payload) { if (payload.boost  != state.data[payload.id].boost) state.data[payload.id].boost = payload.boost },


### PR DESCRIPTION
Just a small thing I noticed. I see this mainly happen on the Technology pane, but any time an unlock occurs for the pane that is already active, the notification badge still appears.

This change prevents the notification from being added in the first place if you're already on that pane.

Perhaps you still intend for the user to see a badge even though they're on that Pane, in which case maybe still add the notification, but clear it when *leaving* the Pane?