### PR TITLE
Add a shortcut for EMC next to Costs

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -591,6 +591,12 @@
                                             <option value="60">{{ $t('1minute') }}</option>
                                         </select>
                                     </div>
+                                    <div class="col-12 mt-2">
+                                        <div class="form-check">
+                                            <input class="form-check-input" type="checkbox" id="checkEmcShortcut" v-model="showEmcShortcut" @click="setDisplayEmcShortcut(!showEmcShortcut)" />
+                                            <label class="form-check-label small" for="checkEmcShortcut">{{ $t('showEmcShortcut') }}</label>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                         </card>
@@ -2406,6 +2412,7 @@ export default {
             
             selectedEmcAmount: null,
             selectedAutoEmcInterval: null,
+            showEmcShortcut: null,
             
             titanSource: null,
             titanDestination: null,
@@ -2418,7 +2425,7 @@ export default {
             'resAchievements', 'prodAchievements', 'newAchievement',
             'notifAutoSave', 'notifAchievement', 'displayLockedItems', 'displayPinnedItems', 'displayDoneTechs', 'displayRoadmap',
             'username', 'token',
-            'emcAmount', 'autoEmcInterval', 'timeSinceAutoEmc',
+            'emcAmount', 'autoEmcInterval', 'displayEmcShortcut', 'timeSinceAutoEmc',
             'stats', 'resources', 'pinned', 'titanSwapingCount',
         ]),
         ...mapGetters([
@@ -2437,7 +2444,7 @@ export default {
         ...mapMutations([
         
             'setLocale', 'setActivePane', 'setLastUpdateTime', 'setTimeSinceAutoSave', 'setCompanyName', 'setAutoSaveInterval',
-            'setNotifAutoSave', 'setNotifAchievement', 'setDisplayLockedItems', 'setUsername', 'setToken', 'setEmcAmount', 'setTimeSinceAutoEmc', 'setAutoEmcInterval',
+            'setNotifAutoSave', 'setNotifAchievement', 'setDisplayLockedItems', 'setUsername', 'setToken', 'setEmcAmount', 'setTimeSinceAutoEmc', 'setAutoEmcInterval', 'setDisplayEmcShortcut',
             'setDisplayPinnedItems', 'setDisplayDoneTechs', 'setDisplayRoadmap',
         ]),
         ...mapActions([
@@ -2469,6 +2476,7 @@ export default {
             this.login = this.username
             this.selectedEmcAmount = this.emcAmount
             this.selectedAutoEmcInterval = this.autoEmcInterval / 1000
+            this.displayEmcShortcut = this.showEmcShortcut
             
             this.ghUpdate()
             
@@ -2490,6 +2498,7 @@ export default {
                 this.showPinnedItems = this.displayPinnedItems
                 this.showDoneTechs = this.displayDoneTechs
                 this.showRoadmap = this.displayRoadmap
+                this.showEmcShortcut = this.displayEmcShortcut
                 
                 element = document.getElementById('toastAchievement')
                 this.toastAchievement = new Toast(element)

--- a/src/components/Costs.vue
+++ b/src/components/Costs.vue
@@ -34,6 +34,13 @@
                 </button>
             </div>
             <div class="col-auto">
+                <button v-if="cost.timer > 0 && isEmcResource(data, getEmcId(cost.id))" class="me-3" @click="if (cost.id != 'segment' && data[cost.id].unlocked == true) { convert(getEmcId(cost.id)); }">
+                    <img :src="require(`../assets/interface/energy.png`)" width="12" height="12" :alt="$t('energy') + ' icon'" />
+                    <i class="mx-1 fas fa-fw fa-long-arrow-alt-right" aria-hidden="true"></i>
+                    <img :src="require(`../assets/interface/${cost.id}.png`)" width="12" height="12" :alt="$t(cost.id) + ' icon'" />
+                </button>
+            </div>
+            <div class="col-auto">
                 <small v-if="!cost.timer || cost.timer > -2" class="text-uppercase text-light">{{ numeralFormat(cost.count.toPrecision(4), '0.[000]a') }}</small>
                 <small v-if="cost.timer <= -2" class="text-uppercase text-danger">{{ numeralFormat(cost.count.toPrecision(4), '0.[000]a') }}</small>
             </div>
@@ -48,7 +55,7 @@
 </template>
 
 <script>
-import { mapState, mapMutations } from 'vuex'
+import { mapState, mapActions, mapMutations } from 'vuex'
 
 export default {
     props: [ 'costs', 'mod', 'id', 'calc' ],
@@ -61,6 +68,15 @@ export default {
         ...mapMutations([
             'setActivePane',
         ]),
+        ...mapActions([
+            'convert',
+        ]),
+        getEmcId(id) {
+            return `emc${id[0].toUpperCase()}${id.slice(1)}`
+        },
+        isEmcResource(data, emcId) {
+            return !!data[emcId]
+        }
     },
 }
 </script>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1101,6 +1101,7 @@
     "costs": "Costs",
     "bigTimer": "> 48h",
     "selectEmcAmount": "Select Amount",
+    "showEmcShortcut": "Display EMC shortcut",
     "changeLog": "Change Log",
     "notEnoughInputCount": "No production, not enough input count",
     "notEnoughInputStorage": "No production, not enough input storage",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1068,6 +1068,7 @@
     "costs": "Coûts",
     "bigTimer": "> 48h",
     "selectEmcAmount": "Choisissez un montant",
+    "showEmcShortcut": "Afficher le raccourci CEM",
     "changeLog": "Change Log",
     "notEnoughInputCount": "Pas de production, pas assez de",
     "notEnoughInputStorage": "Pas de production, stockage trop petit",

--- a/src/store.js
+++ b/src/store.js
@@ -74,6 +74,7 @@ export const store = createStore({
             displayPinnedItems: false,
             displayDoneTechs: true,
             displayRoadmap: true,
+            displayEmcShortcut: false,
             collapsed: [],
             pinned: [],
             /*----------------------------------------------------------------*/
@@ -360,6 +361,7 @@ export const store = createStore({
         setEmcAmount(state, payload) { state.emcAmount = payload },
         setAutoResource(state, payload) { state.autoResource = payload },
         setAutoEmcInterval(state, payload) { state.autoEmcInterval = payload * 1000 },
+        setDisplayEmcShortcut(state, payload) { state.displayEmcShortcut = payload },
         /*--------------------------------------------------------------------*/
         setActivePane(state, payload) {
 
@@ -1580,6 +1582,7 @@ export const store = createStore({
                 state.emcAmount = data.emcAmount || 'max'
                 state.autoResource = data.autoResource
                 state.autoEmcInterval = data.autoEmcInterval || 1 * 1000
+                state.displayEmcShortcut = data.displayEmcShortcut || false,
                 state.collapsed = data.collapsed || []
                 state.pinned = data.pinned || []
                 state.titanSwapingCount = data.titanSwapingCount || 0
@@ -1777,6 +1780,7 @@ export const store = createStore({
                 emcAmount: state.emcAmount,
                 autoResource: state.autoResource,
                 autoEmcInterval: state.autoEmcInterval,
+                displayEmcShortcut: state.displayEmcShortcut,
                 stats: state.stats,
                 collapsed: state.collapsed,
                 pinned: state.pinned,


### PR DESCRIPTION
For #23 

> ![image](https://camo.githubusercontent.com/3a63fc84a86ec914875317055d5a29f67af9db3996a3d65c3e52f79a65c15f28/68747470733a2f2f692e696d6775722e636f6d2f3746536e395a4f2e676966)

The shortcut is only shown next to Costs that aren't full.
Of course, I can understand why someone would want to disable it, so I added an option to the EMC pane and made the default value "false":
![image](https://user-images.githubusercontent.com/13744678/126387587-a526de5b-d735-4001-801f-16f8f8933b4a.png)
 
It displays correctly if you have Auto-EMC unlocked:
![image](https://user-images.githubusercontent.com/13744678/126387830-13f126c6-b475-4f8f-a3ee-4e54abf46910.png)
 
And since I'm from Québec, I also did the french translation:
![image](https://user-images.githubusercontent.com/13744678/126390748-2a070f72-6108-4bb9-a640-7b8a64c3deaa.png)
 
---

I added one new boolean `displayEmcShortcut` to the state and save, and a `showEmcShortcut` as a model for the new checkbox.
I added `setDisplayEmcShortcut()`, and two methods in Costs. 

I only used Bootstrap for the visual style of the button. I kinda wanted to make it a `.btn`, but that messes up the height of the costs.
